### PR TITLE
Add whitelist of files to be published on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   "main": "./lib/client.js",
   "scripts": {
     "test": "grunt"
-  }
+  },
+  "files": [
+    "/lib"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
     "test": "grunt"
   },
   "files": [
-    "/lib"
+    "lib"
   ]
 }


### PR DESCRIPTION
This reduces the size of the package from 17.9 kB (61.7 kB unpacked) to 15.2 kB (45.3 kB unpacked).