### PR TITLE
Add publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+on:
+  release:
+    types: [created, edited, published]
+  workflow_dispatch:
+    inputs:
+      dryRun:
+        description: "Dry run only"
+        required: true
+        default: true
+        type: boolean
+  
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: "https://registry.npmjs.org"
+      - run: npm ci
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+        if: >
+          (github.event_name == 'release' && github.event.action == 'published') ||
+          (github.event_name == 'workflow_dispatch' && !inputs.dryRun)
+        run: npm publish
+
+      - name: Publish package (dry run)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+        if: >
+          (github.event_name == 'release' && github.event.action != 'published') ||
+          (github.event_name == 'workflow_dispatch' && inputs.dryRun)
+        run: npm publish --dry-run

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: "https://registry.npmjs.org"
       - run: npm ci
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 


### PR DESCRIPTION
This PR adds a publishing workflow.  See https://github.com/pa11y/pa11y-lint-config/pull/6.  This is a duplicate of that implementation; the YAML may be centralised later if no need for differentiation emerges.

The test workflow is also updated to remove the `master` branch trigger.