### PR TITLE
Release `pa11y-webservice-client-node@4`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+For versions below `4.0.0`, see the project's [tags](https://github.com/pa11y/pa11y-webservice-client-node/tags) on GitHub.
+
+## 4.0.0
+
+### Changes
+
+* **Major:** Require Node.js `18-20`, up from `12-16`
+* **Major:** `pa11y-webservice@4` is now unambiguously licensed as `LGPL-3.0-only`
+* **Major:** Update support policy
+* Improve project verification and publishing
+
+### New contributors
+
+* @danyalaytekin made their first contribution in https://github.com/pa11y/pa11y-webservice-client-node/pull/19
+
+### Full diff
+
+[3.0.0...4.0.0](https://github.com/pa11y/pa11y-webservice-client-node/compare/3.0.0...4.0.0)
+

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -4,12 +4,12 @@ This package's API and/or supported set of environments changes between major ve
 
 ## Migrating to 4 from 3
 
-1. Upgrade to Node.js 18 or above.
+1. Upgrade to Node.js 18 or 20.
 
 ## Migrating to 3 from 2
 
-1. Upgrade to Node.js 12 or above. 
+1. Upgrade to Node.js 12, 14, or 16.
 
 ## Migrating to 2 from 1
 
-1. Upgrade to Node.js 8 or above.
+1. Upgrade to Node.js 8 or 10.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a Node.js client library for [Pa11y Webservice][pa11y-webservice].
 
 [![Latest version published to npm][shield-npm]][info-npm]
 [![Node.js version support][shield-node]][info-node]
+[![Supports pa11y-webservice@4 API][shield-api]][pa11y-webservice]
 [![Build status][shield-build]][info-build]
 [![LGPL-3.0 licensed][shield-license]][info-license]
 
@@ -195,11 +196,14 @@ Copyright &copy; 2013-2024, Team Pa11y
 
 [pa11y-webservice]: https://github.com/pa11y/pa11y-webservice
 [wiki-web-service]: https://github.com/pa11y/pa11y-webservice/wiki/Web-Service-Endpoints
+
 [info-build]: https://github.com/pa11y/pa11y-webservice-client-node/actions/workflows/tests.yml
 [info-license]: LICENSE
 [info-node]: package.json
 [info-npm]: https://www.npmjs.com/package/pa11y-webservice-client-node
+
 [shield-build]: https://github.com/pa11y/pa11y-webservice-client-node/actions/workflows/tests.yml/badge.svg
 [shield-license]: https://img.shields.io/badge/license-LGPL%203.0-blue.svg
 [shield-node]: https://img.shields.io/node/v/pa11y-webservice-client-node.svg
 [shield-npm]: https://img.shields.io/npm/v/pa11y-webservice-client-node.svg
+[shield-api]: https://img.shields.io/badge/api-pa11y--webservice@4-blue.svg

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ The following table lists the major versions available and, for each previous ma
 
 | Major version   | Final minor version | Node.js support          | Support end date |
 | :-------------- | :------------------ | :----------------------- | :--------------- |
-| `3`             |                     | `>= 12`                  | ✅ Current major version |
+| `4`             |                     | `18`, `20`               | ✅ Current major version |
+| `3`             | `3.0`               | `12`, `14`, `16`         | September 2024   |
 | `2`             | `2.0`               | `8`, `10`                | 2022-05-26       |
 | `1`             | `1.2`               | `0.10`, `0.12`, `4`, `6` | 2020-01-05       |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pa11y-webservice-client-node",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pa11y-webservice-client-node",
-      "version": "3.0.0",
+      "version": "4.0.0",
       "license": "LGPL-3.0-only",
       "dependencies": {
         "request": "~2.88.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pa11y-webservice-client-node",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
> [!NOTE]
> 1. `pa11y-bot` will release `pa11y-webservice-client-node@4.0.0` from `main` once this is merged and the [draft GitHub Release](https://github.com/pa11y/pa11y-webservice-client-node/releases) published
> 2. [Full diff since `3.0.0`](https://github.com/pa11y/pa11y-webservice-client-node/compare/3.0.0...version-4)

### Components

- [x] #19
- [x] #21 
- [x] #22 
- [x] #23 

### Changes in this PR

- [x] Add custom badge to show `pa11y-webservice` API support https://github.com/pa11y/pa11y-webservice-client-node/pull/24/commits/8bb53337310c23e3c83c647f8ec310dd16384d5e
- [x] Update `package*.json`
- [x] Add `CHANGELOG.md` file and an entry for `4.0.0`
- [x] Add `MIGRATION.md` entry
- [x] Update `README.md`
- [x] Create [draft release](https://github.com/pa11y/pa11y-webservice-client-node/releases)